### PR TITLE
Add support to keep unknown characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,11 @@ console.log(ASCIIFolder.fold("★Lorém ïpsum dölor.", "_"));
 
 // Folding without replacement of unmapped characters:
 console.log(ASCIIFolder.fold("★Lorém ïpsum dölor.", null));
+// Results in "★Lorem ipsum dolor."
+
+// Folding with removal of unmapped characters
 console.log(ASCIIFolder.fold("★Lorém ïpsum dölor."));
-// Both calls result in "Lorem ipsum dolor."
+// Results in "Lorem ipsum dolor."
 ```
 
 If no replacement parameter is specified, unmapped characters will be replaced by the empty string.

--- a/lib/ascii-folder.js
+++ b/lib/ascii-folder.js
@@ -57,7 +57,7 @@ class ASCIIFolder {
      */
     static replaceChar(char, replacement) {
         let ascii = ASCIIFolder.mapping.get(char.charCodeAt(0));
-        return ascii ? ascii : replacement;
+        return ascii ? ascii : (replacement === null ? char : replacement);
     }
 }
 

--- a/test/ascii-folder.js
+++ b/test/ascii-folder.js
@@ -33,6 +33,14 @@ QUnit.test("asciiPrintableTest", function () {
     equal(ASCIIFolder.fold("0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~ !\"#$%&'()*+,-./"), "0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~ !\"#$%&'()*+,-./", "This is expected to return the ASCII printable characters.");
 });
 
+QUnit.test("keepsUnknownCharactersTest", function () {
+    equal(ASCIIFolder.fold("🤧😇", null), "🤧😇", "This is expected to return the ASCII printable characters.");
+});
+
+QUnit.test("replacesUnknownCharactersTest", function () {
+    equal(ASCIIFolder.fold("🤧😇"), "", "This is expected to return the ASCII printable characters.");
+});
+
 QUnit.test("ATest", function () {
     equal(ASCIIFolder.fold(String.fromCharCode(0xc0)), "A", "This is function is expected to escape the unicode sequence \"\\u00C0\" to \"A\"");
     equal(ASCIIFolder.fold(String.fromCharCode(0xc1)), "A", "This is function is expected to escape the unicode sequence \"\\u00C1\" to \"A\"");


### PR DESCRIPTION
According to the documentation, if `replacement` parameter is `null` then original character is kept.