### PR TITLE
Use class name instead of this in static methods

### DIFF
--- a/lib/ascii-folder.js
+++ b/lib/ascii-folder.js
@@ -22,11 +22,11 @@
 class ASCIIFolder {
 
     static foldReplacing(str = '', replacement = '') {
-        return this._fold(str, () => replacement);
+        return ASCIIFolder._fold(str, () => replacement);
     }
 
     static foldMaintaining(str = '') {
-        return this._fold(str, (char) => char);
+        return ASCIIFolder._fold(str, (char) => char);
     }
 
     static _fold(str, fallback) {
@@ -43,7 +43,7 @@ class ASCIIFolder {
             if (character.charCodeAt(0) < 128) {
                 return character;
             } else {
-                const replacement = this.mapping.get(character.charCodeAt(0));
+                const replacement = ASCIIFolder.mapping.get(character.charCodeAt(0));
                 return (replacement === undefined) ? fallback(character) : replacement;
             }
         }).join('');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,50 +1,73 @@
 {
   "name": "fold-to-ascii",
   "version": "5.0.1",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "commander": {
+  "packages": {
+    "": {
+      "name": "fold-to-ascii",
+      "version": "5.0.1",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "qunit": "^2.20.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/commander": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
       "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      }
     },
-    "globalyzer": {
+    "node_modules/globalyzer": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
       "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
       "dev": true
     },
-    "globrex": {
+    "node_modules/globrex": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
       "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
       "dev": true
     },
-    "node-watch": {
+    "node_modules/node-watch": {
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.7.3.tgz",
       "integrity": "sha512-3l4E8uMPY1HdMMryPRUAl+oIHtXtyiTlIiESNSVSNxcPfzAFzeTbXFQkZfAwBbo0B1qMSG8nUABx+Gd+YrbKrQ==",
-      "dev": true
-    },
-    "qunit": {
-      "version": "2.19.1",
-      "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.19.1.tgz",
-      "integrity": "sha512-gSGuw0vErE/rNjnlBW/JmE7NNubBlGrDPQvsug32ejYhcVFuZec9yoU0+C30+UgeCGwq6Ap89K65dMGo+kDGZQ==",
       "dev": true,
-      "requires": {
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qunit": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.20.0.tgz",
+      "integrity": "sha512-N8Fp1J55waE+QG1KwX2LOyqulZUToRrrPBqDOfYfuAMkEglFL15uwvmH1P4Tq/omQ/mGbBI8PEB3PhIfvUb+jg==",
+      "dev": true,
+      "dependencies": {
         "commander": "7.2.0",
         "node-watch": "0.7.3",
         "tiny-glob": "0.2.9"
+      },
+      "bin": {
+        "qunit": "bin/qunit.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
-    "tiny-glob": {
+    "node_modules/tiny-glob": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
       "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "globalyzer": "0.1.0",
         "globrex": "^0.1.2"
       }

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
   },
   "homepage": "https://github.com/mplatt/fold-to-ascii",
   "devDependencies": {
-    "qunit": "2.19.1"
+    "qunit": "^2.20.0"
   },
   "engines": {
-    "node": ">= 6.3.1"
+    "node": ">= 10"
   }
 }


### PR DESCRIPTION
`this` operator was used within static methods to call other static methods from the same class. Looks like this does not work in conjunction with newer typescript versions (or with specific typescript configurations). This PR addresses that problem. Furthermore the `qunit` dependency was updated and the minimum node version was "set" to 10.